### PR TITLE
Fix query showing locations meant to be invisible

### DIFF
--- a/lib/elastix/location/query.ex
+++ b/lib/elastix/location/query.ex
@@ -70,7 +70,7 @@ defmodule Elastix.Location.Query do
           ],
           should: [
             %{ match: %{ state: "active" }},
-            %{ match: %{ shown_as_rented_out: true }}
+            %{ range: %{ show_as_rented_out_until: %{ from: "now" } } }
           ],
           minimum_should_match: 1
         }
@@ -95,7 +95,7 @@ defmodule Elastix.Location.Query do
               ],
               should: [
                 %{ match: %{ state: "active" }},
-                %{ match: %{ shown_as_rented_out: true }}
+                %{ range: %{ show_as_rented_out_until: %{ from: "now" } } }
               ],
               minimum_should_match: 1
             }


### PR DESCRIPTION
... or the rented out locations, where the
show_as_rented_out_until date is exeeded